### PR TITLE
Use ParserTestDriver

### DIFF
--- a/test/test_grok_parser.rb
+++ b/test/test_grok_parser.rb
@@ -73,8 +73,7 @@ class GrokParserTest < ::Test::Unit::TestCase
   private
 
   def internal_test_grok_pattern(grok_pattern, text, expected_time, expected_record, options = {})
-    parser = TextParser::GrokParser.new
-    parser.configure(Config::Element.new('ROOT', '', {"grok_pattern" => grok_pattern}.merge(options), []))
+    parser = Fluent::Test::ParserTestDriver.new(TextParser::GrokParser).configure({"grok_pattern" => grok_pattern}.merge(options))
 
     # for the old, return based API
     time, record = parser.parse(text)

--- a/test/test_multiline_grok_parser.rb
+++ b/test/test_multiline_grok_parser.rb
@@ -52,9 +52,6 @@ TEXT
   private
 
   def create_parser(conf)
-    parser = TextParser::MultilineGrokParser.new
-    io = StringIO.new(conf)
-    parser.configure(Config::Parser.parse(io, "fluent.conf"))
-    parser
+    Fluent::Test::ParserTestDriver.new(TextParser::MultilineGrokParser).configure(conf)
   end
 end


### PR DESCRIPTION
Now, we can use `ParserTestDriver` in parser plugin test!